### PR TITLE
Protect Results

### DIFF
--- a/SwiftCheck.xcodeproj/project.pbxproj
+++ b/SwiftCheck.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		84DF76201B0BD58900C912B0 /* ModifierSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8480AB2C1A7B0A9700C6162D /* ModifierSpec.swift */; };
 		84DF76211B0BD58900C912B0 /* BooleanIdentitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848076671AF5D6A100CBE3EF /* BooleanIdentitySpec.swift */; };
 		84DF76241B0BD99900C912B0 /* SwiftCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = 844FCC92198B320500EB242A /* SwiftCheck.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84EA2C391B2287200001FB3F /* PropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EA2C381B2287200001FB3F /* PropertySpec.swift */; };
+		84EA2C3A1B2287200001FB3F /* PropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EA2C381B2287200001FB3F /* PropertySpec.swift */; };
 		84F2C4F71A7AD43F00316E5F /* Modifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2C4F61A7AD43F00316E5F /* Modifiers.swift */; };
 		D46395B61B1A94D200AA1B65 /* Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46395B51B1A94D200AA1B65 /* Equatable.swift */; };
 		D46395B71B1A94D200AA1B65 /* Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46395B51B1A94D200AA1B65 /* Equatable.swift */; };
@@ -110,6 +112,7 @@
 		8480AB2C1A7B0A9700C6162D /* ModifierSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierSpec.swift; sourceTree = "<group>"; };
 		84DF75F81B0BD54600C912B0 /* SwiftCheck.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCheck.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84DF76021B0BD54600C912B0 /* SwiftCheck-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftCheck-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		84EA2C381B2287200001FB3F /* PropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertySpec.swift; sourceTree = "<group>"; };
 		84F2C4F61A7AD43F00316E5F /* Modifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Modifiers.swift; sourceTree = "<group>"; };
 		D46395B51B1A94D200AA1B65 /* Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Equatable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -205,6 +208,7 @@
 				848076671AF5D6A100CBE3EF /* BooleanIdentitySpec.swift */,
 				84572C201A6DBA1C00241F68 /* DiscardSpec.swift */,
 				8445C4A91B16D37800280089 /* GenSpec.swift */,
+				84EA2C381B2287200001FB3F /* PropertySpec.swift */,
 				8480AB2C1A7B0A9700C6162D /* ModifierSpec.swift */,
 				8445C4AC1B17E48300280089 /* ShrinkSpec.swift */,
 				844FCCC8198EFF9B00EB242A /* SimpleSpec.swift */,
@@ -417,6 +421,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84EA2C391B2287200001FB3F /* PropertySpec.swift in Sources */,
 				8445C4A31B16897200280089 /* DiscardSpec.swift in Sources */,
 				8445C4AD1B17E48300280089 /* ShrinkSpec.swift in Sources */,
 				8445C4AA1B16D37800280089 /* GenSpec.swift in Sources */,
@@ -451,6 +456,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84EA2C3A1B2287200001FB3F /* PropertySpec.swift in Sources */,
 				84DF761E1B0BD58900C912B0 /* SimpleSpec.swift in Sources */,
 				8445C4AE1B17E48300280089 /* ShrinkSpec.swift in Sources */,
 				8445C4AB1B16D37800280089 /* GenSpec.swift in Sources */,

--- a/SwiftCheck/Operators.swift
+++ b/SwiftCheck/Operators.swift
@@ -35,7 +35,7 @@ infix operator ==== {
 
 /// Like equality but prints a verbose description when it fails.
 public func ====<A where A : Equatable, A : Printable>(x : A, y : A) -> Property {
-	return counterexample(x.description + "/=" + y.description)(p: x == y)
+	return counterexample(toDebugString(x) + "/=" + toDebugString(y))(p: x == y)
 }
 
 

--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -117,7 +117,7 @@ public func withCallback(cb : Callback)(p : Testable) -> Property {
 			labels: res.labels,
 			stamp: res.stamp,
 			callbacks: [cb] + res.callbacks,
-			abort: false)
+			abort: res.abort)
 	})(p: p)
 }
 
@@ -183,7 +183,7 @@ public func verbose(p : Testable) -> Property {
 			labels: res.labels,
 			stamp: res.stamp,
 			callbacks: res.callbacks + chattyCallbacks(res.callbacks),
-			abort: false)
+			abort: res.abort)
 	})(p: p)
 }
 
@@ -199,7 +199,7 @@ public func expectFailure(p : Testable) -> Property {
 			labels: res.labels,
 			stamp: res.stamp,
 			callbacks: res.callbacks,
-			abort: false)
+			abort: res.abort)
 	})(p: p)
 }
 
@@ -236,7 +236,7 @@ public func cover(b : Bool)(n : Int)(s : String)(p : Testable) -> Property {
 				labels: insertWith(max, s, n, res.labels),
 				stamp: res.stamp.union([s]),
 				callbacks: res.callbacks,
-				abort: false)
+				abort: res.abort)
 		})(p: p)
 	}
 	return p.property()
@@ -381,7 +381,7 @@ private func addCallbacks(result : TestResult) -> TestResult -> TestResult {
 			labels: res.labels,
 			stamp: res.stamp,
 			callbacks: result.callbacks + res.callbacks,
-			abort: false)
+			abort: res.abort)
 	}
 }
 
@@ -394,7 +394,7 @@ private func addLabels(result : TestResult) -> TestResult -> TestResult {
 			labels: unionWith(max, res.labels, result.labels),
 			stamp: res.stamp.union(result.stamp),
 			callbacks: res.callbacks,
-			abort: false)
+			abort: res.abort)
 	}
 }
 

--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -343,7 +343,7 @@ private func result(ok : Bool?, reason : String = "") -> TestResult {
 	return TestResult(ok: ok, expect: true, reason: reason, theException: .None, labels: [:], stamp: Set(), callbacks: [], abort: false)
 }
 
-internal func id<A>(x : A) -> A {
+private func id<A>(x : A) -> A {
 	return x
 }
 

--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -82,6 +82,20 @@ public func shrinking<A>(shrinker : A -> [A], initial : A, prop : A -> Testable)
 	})
 }
 
+/// Modifies a property so that it only will be tested once. 
+public func once(p : Testable) -> Property {
+	return mapResult({ (var res) in
+		return TestResult(ok: res.ok,
+			expect: res.expect,
+			reason: res.reason,
+			theException: res.theException,
+			labels: res.labels,
+			stamp: res.stamp,
+			callbacks: res.callbacks,
+			abort: true)
+	})(p: p)
+}
+
 /// Modifies a property so it will not shrink when it fails.
 public func noShrinking(p : Testable) -> Property {
 	return mapRoseResult({ rs in
@@ -102,7 +116,8 @@ public func withCallback(cb : Callback)(p : Testable) -> Property {
 			theException: res.theException,
 			labels: res.labels,
 			stamp: res.stamp,
-			callbacks: [cb] + res.callbacks)
+			callbacks: [cb] + res.callbacks,
+			abort: false)
 	})(p: p)
 }
 
@@ -167,7 +182,8 @@ public func verbose(p : Testable) -> Property {
 			theException: res.theException,
 			labels: res.labels,
 			stamp: res.stamp,
-			callbacks: res.callbacks + chattyCallbacks(res.callbacks))
+			callbacks: res.callbacks + chattyCallbacks(res.callbacks),
+			abort: false)
 	})(p: p)
 }
 
@@ -182,7 +198,8 @@ public func expectFailure(p : Testable) -> Property {
 			theException: res.theException,
 			labels: res.labels,
 			stamp: res.stamp,
-			callbacks: res.callbacks)
+			callbacks: res.callbacks,
+			abort: false)
 	})(p: p)
 }
 
@@ -218,7 +235,8 @@ public func cover(b : Bool)(n : Int)(s : String)(p : Testable) -> Property {
 				theException: res.theException,
 				labels: insertWith(max, s, n, res.labels),
 				stamp: res.stamp.union([s]),
-				callbacks: res.callbacks)
+				callbacks: res.callbacks,
+				abort: false)
 		})(p: p)
 	}
 	return p.property()
@@ -249,6 +267,7 @@ public enum TestResultMatcher {
 					, labels : Dictionary<String, Int>
 					, stamp : Set<String>
 					, callbacks : [Callback]
+					, abort : Bool
 					)
 }
 
@@ -269,13 +288,15 @@ public struct TestResult {
 	let stamp			: Set<String>
 	/// Callbacks attached to the test case.
 	let callbacks		: [Callback]
+	/// Indicates that any further testing of the property should cease.
+	let abort			: Bool
 
 	/// Destructures a test case into a matcher that can be used in switch statement.
 	public func match() -> TestResultMatcher {
-		return .MatchResult(ok: ok, expect: expect, reason: reason, theException: theException, labels: labels, stamp: stamp, callbacks: callbacks)
+		return .MatchResult(ok: ok, expect: expect, reason: reason, theException: theException, labels: labels, stamp: stamp, callbacks: callbacks, abort: abort)
 	}
 
-	public init(ok : Optional<Bool>, expect : Bool, reason : String, theException : Optional<String>, labels : Dictionary<String, Int>, stamp : Set<String>, callbacks : [Callback]) {
+	public init(ok : Optional<Bool>, expect : Bool, reason : String, theException : Optional<String>, labels : Dictionary<String, Int>, stamp : Set<String>, callbacks : [Callback], abort : Bool) {
 		self.ok = ok
 		self.expect = expect
 		self.reason = reason
@@ -283,6 +304,7 @@ public struct TestResult {
 		self.labels = labels
 		self.stamp = stamp
 		self.callbacks = callbacks
+		self.abort = abort
 	}
 }
 ///
@@ -318,10 +340,10 @@ private func props<A>(shrinker : A -> [A], #original : A, #pf: A -> Testable) ->
 }
 
 private func result(ok : Bool?, reason : String = "") -> TestResult {
-	return TestResult(ok: ok, expect: true, reason: reason, theException: .None, labels: [:], stamp: Set(), callbacks: [])
+	return TestResult(ok: ok, expect: true, reason: reason, theException: .None, labels: [:], stamp: Set(), callbacks: [], abort: false)
 }
 
-private func id<A>(x : A) -> A {
+internal func id<A>(x : A) -> A {
 	return x
 }
 
@@ -358,7 +380,8 @@ private func addCallbacks(result : TestResult) -> TestResult -> TestResult {
 			theException: res.theException,
 			labels: res.labels,
 			stamp: res.stamp,
-			callbacks: result.callbacks + res.callbacks)
+			callbacks: result.callbacks + res.callbacks,
+			abort: false)
 	}
 }
 
@@ -370,7 +393,8 @@ private func addLabels(result : TestResult) -> TestResult -> TestResult {
 			theException: res.theException,
 			labels: unionWith(max, res.labels, result.labels),
 			stamp: res.stamp.union(result.stamp),
-			callbacks: res.callbacks)
+			callbacks: res.callbacks,
+			abort: false)
 	}
 }
 
@@ -467,7 +491,8 @@ private func disj(p : Rose<TestResult>, q : Rose<TestResult>) -> Rose<TestResult
 						stamp: Set(),
 						callbacks: result1.callbacks + [.AfterFinalFailure(kind: .Counterexample, f: { _ in
 							return println("")
-						})] + result2.callbacks))
+						})] + result2.callbacks,
+						abort: false))
 				case .None:
 					return Rose.pure(result2)
 				default:

--- a/SwiftCheck/State.swift
+++ b/SwiftCheck/State.swift
@@ -23,8 +23,9 @@ public struct State {
 	let numSuccessShrinks	: Int
 	let numTryShrinks		: Int
 	let numTotTryShrinks	: Int
+	let shouldAbort			: Bool
 
-	public init(name : String, maxSuccessTests : Int, maxDiscardedTests : Int, computeSize : Int -> Int -> Int, numSuccessTests : Int, numDiscardedTests : Int, labels : Dictionary<String, Int>, collected : [Set<String>], expectedFailure : Bool, randomSeed : StdGen, numSuccessShrinks : Int, numTryShrinks : Int, numTotTryShrinks : Int) {
+	public init(name : String, maxSuccessTests : Int, maxDiscardedTests : Int, computeSize : Int -> Int -> Int, numSuccessTests : Int, numDiscardedTests : Int, labels : Dictionary<String, Int>, collected : [Set<String>], expectedFailure : Bool, randomSeed : StdGen, numSuccessShrinks : Int, numTryShrinks : Int, numTotTryShrinks : Int, shouldAbort : Bool) {
 		self.name = name
 		self.maxSuccessTests = maxSuccessTests
 		self.maxDiscardedTests = maxDiscardedTests
@@ -38,5 +39,6 @@ public struct State {
 		self.numSuccessShrinks = numSuccessShrinks
 		self.numTryShrinks = numTryShrinks
 		self.numTotTryShrinks = numTotTryShrinks
+		self.shouldAbort = shouldAbort
 	}
 }

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -223,8 +223,10 @@ internal func quickCheckWithResult(args : Arguments, p : Testable) -> Result {
 					, randomSeed:			rnd()
 					, numSuccessShrinks:	0
 					, numTryShrinks:		0
-					, numTotTryShrinks:		0)
-	return test(state, p.property().unProperty.unGen)
+					, numTotTryShrinks:		0
+					, shouldAbort:			false)
+	let modP : Property = (p.exhaustive ? once(p.property()) : p.property())
+	return test(state, modP.unProperty.unGen)
 }
 
 // Main Testing Loop:
@@ -250,13 +252,14 @@ internal func test(st : State, f : (StdGen -> Int -> Prop)) -> Result {
 					return fail.value.0
 				}
 			case let .Right(sta):
-				if sta.value.numSuccessTests >= sta.value.maxSuccessTests {
-					return doneTesting(sta.value)(f: f)
+				let lsta = sta.value // Local copy so I don't have to keep unwrapping.
+				if lsta.numSuccessTests >= lsta.maxSuccessTests || lsta.shouldAbort {
+					return doneTesting(lsta)(f: f)
 				}
-				if sta.value.numDiscardedTests >= sta.value.maxDiscardedTests {
-					return giveUp(sta.value)(f: f)
+				if lsta.numDiscardedTests >= lsta.maxDiscardedTests || lsta.shouldAbort {
+					return giveUp(lsta)(f: f)
 				}
-				state = sta.value
+				state = lsta
 		}
 	}
 }
@@ -276,7 +279,7 @@ internal func runATest(st : State)(f : (StdGen -> Int -> Prop)) -> Either<(Resul
 
 			switch res.match() {
 				// Success
-				case .MatchResult(.Some(true), let expect, _, _, let labels, let stamp, _):
+				case .MatchResult(.Some(true), let expect, _, _, let labels, let stamp, _, let abort):
 					let state = State(name: st.name
 									, maxSuccessTests: st.maxSuccessTests
 									, maxDiscardedTests: st.maxDiscardedTests
@@ -289,10 +292,11 @@ internal func runATest(st : State)(f : (StdGen -> Int -> Prop)) -> Either<(Resul
 									, randomSeed: st.randomSeed
 									, numSuccessShrinks: st.numSuccessShrinks
 									, numTryShrinks: st.numTryShrinks
-									, numTotTryShrinks: st.numTotTryShrinks)
+									, numTotTryShrinks: st.numTotTryShrinks
+									, shouldAbort: abort)
 					return .Right(Box(state))
 				// Discard
-				case .MatchResult(.None, let expect, _, _, let labels, _, _):
+				case .MatchResult(.None, let expect, _, _, let labels, _, _, let abort):
 					let state = State(name: st.name
 									, maxSuccessTests: st.maxSuccessTests
 									, maxDiscardedTests: st.maxDiscardedTests
@@ -305,10 +309,11 @@ internal func runATest(st : State)(f : (StdGen -> Int -> Prop)) -> Either<(Resul
 									, randomSeed: rnd2
 									, numSuccessShrinks: st.numSuccessShrinks
 									, numTryShrinks: st.numTryShrinks
-									, numTotTryShrinks: st.numTotTryShrinks)
+									, numTotTryShrinks: st.numTotTryShrinks
+									, shouldAbort: abort)
 					return .Right(Box(state))
 				// Fail
-				case .MatchResult(.Some(false), let expect, _, _, _, _, _):
+				case .MatchResult(.Some(false), let expect, _, _, _, _, _, let abort):
 					if !expect {
 						print("+++ OK, failed as expected. ")
 					} else {
@@ -343,8 +348,8 @@ internal func runATest(st : State)(f : (StdGen -> Int -> Prop)) -> Either<(Resul
 									, randomSeed: rnd2
 									, numSuccessShrinks: st.numSuccessShrinks
 									, numTryShrinks: st.numTryShrinks
-									, numTotTryShrinks: st.numTotTryShrinks)
-
+									, numTotTryShrinks: st.numTotTryShrinks
+									, shouldAbort: abort)
 					return .Left(Box((stat, state)))
 			default:
 				fatalError("Pattern Match Failed: switch on a Result was inexhaustive.")
@@ -445,7 +450,8 @@ internal func findMinimalFailingTestCase(st : State, res : TestResult, ts : [Ros
 					, randomSeed: st.randomSeed
 					, numSuccessShrinks: numSuccessShrinks
 					, numTryShrinks: numTryShrinks
-					, numTotTryShrinks: numTotTryShrinks)
+					, numTotTryShrinks: numTotTryShrinks
+					, shouldAbort: st.shouldAbort)
 	return reportMinimumCaseFound(state, lastResult)
 }
 

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -107,7 +107,7 @@ public func forAll<A : Arbitrary, B : Arbitrary, C : Arbitrary, D : Arbitrary, E
 public func forAllShrink<A>(gen : Gen<A>, shrinker: A -> [A], f : A -> Testable) -> Property {
 	return Property(gen.bind { x in
 		return shrinking(shrinker, x, { xs  in
-			return counterexample("\(xs)")(p: f(xs))
+			return counterexample(toDebugString(xs))(p: f(xs))
 		}).unProperty
 	})
 }

--- a/SwiftCheck/Testable.swift
+++ b/SwiftCheck/Testable.swift
@@ -35,6 +35,10 @@ public struct Property : Testable {
 	}
 }
 
+internal func protectedIORose(f : () throws -> Rose<TestResult>) -> Rose<TestResult> {
+	return .IORose(protectRose(f))
+}
+
 /// A proposition.
 public struct Prop : Testable {
 	var unProp : Rose<TestResult>
@@ -42,7 +46,7 @@ public struct Prop : Testable {
 	public var exhaustive : Bool { return true }
 
 	public func property() -> Property {
-		return Property(Gen.pure(Prop(unProp: .IORose({ self.unProp }))))
+		return Property(Gen.pure(Prop(unProp: .IORose(protectRose({ self.unProp })))))
 	}
 }
 

--- a/SwiftCheck/Testable.swift
+++ b/SwiftCheck/Testable.swift
@@ -57,7 +57,7 @@ public struct Discard : Testable {
 	public init() { }
 
 	public func property() -> Property {
-		return rejected().property()
+		return TestResult.rejected.property()
 	}
 }
 
@@ -73,6 +73,6 @@ extension Bool : Testable {
 	public var exhaustive : Bool { return true }
 
 	public func property() -> Property {
-		return liftBool(self).property()
+		return TestResult.liftBool(self).property()
 	}
 }

--- a/SwiftCheckTests/PropertySpec.swift
+++ b/SwiftCheckTests/PropertySpec.swift
@@ -13,11 +13,11 @@ class PropertySpec : XCTestCase {
 	func testAll() {
 		property("Once really only tests a property once") <- forAll { (n : Int) in
 			var bomb : Optional<Int> = .Some(n)
-			return once(forAll { (_ : Int) in
+			return forAll { (_ : Int) in
 				let b = bomb! // Will explode if we test more than once
 				bomb = nil
 				return b == n
-			})
+			}.once
 		}
 	}
 }

--- a/SwiftCheckTests/PropertySpec.swift
+++ b/SwiftCheckTests/PropertySpec.swift
@@ -1,0 +1,23 @@
+//
+//  PropertySpec.swift
+//  SwiftCheck
+//
+//  Created by Robert Widmann on 6/5/15.
+//  Copyright (c) 2015 Robert Widmann. All rights reserved.
+//
+
+import XCTest
+import SwiftCheck
+
+class PropertySpec : XCTestCase {
+	func testAll() {
+		property["Once really only tests a property once"] = forAll { (n : Int) in
+			var bomb : Optional<Int> = .Some(n)
+			return once(forAll { (_ : Int) in
+				let b = bomb! // Will explode if we test more than once
+				bomb = nil
+				return b == n
+			})
+		}
+	}
+}

--- a/SwiftCheckTests/PropertySpec.swift
+++ b/SwiftCheckTests/PropertySpec.swift
@@ -11,7 +11,7 @@ import SwiftCheck
 
 class PropertySpec : XCTestCase {
 	func testAll() {
-		property["Once really only tests a property once"] = forAll { (n : Int) in
+		property("Once really only tests a property once") <- forAll { (n : Int) in
 			var bomb : Optional<Int> = .Some(n)
 			return once(forAll { (_ : Int) in
 				let b = bomb! // Will explode if we test more than once


### PR DESCRIPTION
Eats exceptions in tests and recasts them as failures.  Assuming this doesn't explode the compiler someday.
